### PR TITLE
src agnostic runtime 🙈

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,5 +61,4 @@ ENTRYPOINT ./entrypoint.sh \
   ./app.key \
   /tools/bin/libsgxlkl.so \
   ./src/Dockerfile \
-  ./app.img \
-  /app/index.js
+  ./app.img

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,11 +82,10 @@ echo "Entrypoint: Docker entrypoint: $DOCKER_IMG_ENTRY"
 
 # Inflate the docker environment into our environment
 # Note: however, we don't allow the docker environment to override some things
-# Namely: PATH, SGXLKL_CWD, SGXLKL_KEY
+# Namely: SGXLKL_CWD, SGXLKL_KEY
 #
 # shellcheck disable=SC2086,SC2163
 export $DOCKER_IMG_ENV
-export PATH=$OUR_PATH
 export SGXLKL_CWD=$DOCKER_IMG_WORKDIR
 export SGXLKL_KEY=$SIGN_KEY_PATH
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,27 +39,27 @@ echo "DOCKER_ENTRY_PATH: $DOCKER_ENTRY_PATH"
 if [[ "$MAKE_TARGET" != "sim" ]]; then
     echo "Entrypoint: Signing..."
     # Sign it, with the above key
-    /tools/bin/sgx-lkl-sign -k $SIGN_KEY_PATH -f $SIGN_KEY_BIN_PATH
+    /tools/bin/sgx-lkl-sign -k "$SIGN_KEY_PATH" -f "$SIGN_KEY_BIN_PATH"
     echo "Entrypoint: Signed."
 fi
 
 # Create our actual disk (that we'll mount in the enclave)
 # Note: as we want to extract info (like entrypoint) from the dockerfile, we give sgx-lkl-disk an existing image, not just the dockerfile
 TMP_DOCKER_IMG_ID=$(cat /proc/sys/kernel/random/uuid)
-docker build -t $TMP_DOCKER_IMG_ID -f $DOCKER_PATH $(dirname $DOCKER_PATH)
+docker build -t "$TMP_DOCKER_IMG_ID" -f "$DOCKER_PATH" "$(dirname "$DOCKER_PATH")"
 
 # Parsing out some critical env vars demands its own section
 # We must determine the image size and remove PATH (we don't allow overriding the host app path)
-DOCKER_IMG_ENV=$(docker image inspect -f "{{range \$conf := .Config.Env}}{{(\$conf)}} {{end}}" $TMP_DOCKER_IMG_ID)
+DOCKER_IMG_ENV=$(docker image inspect -f "{{range \$conf := .Config.Env}}{{(\$conf)}} {{end}}" "$TMP_DOCKER_IMG_ID")
 
 SGXLKL_DISK_SIZE_CONST="SGXLKL_DISK_SIZE"
 
 # If we don't have an image size, we cannot proceed
 if [[ "$DOCKER_IMG_ENV" != *"$SGXLKL_DISK_SIZE_CONST"* ]]; then
-    echo "Docker image does not set '$SGXLKL_DISK_SIZE_CONST'. Please define the LKL disk size using ENV $SGXLK_DISK_SIZE_CONST in '$DOCKER_PATH'."
+    echo "Docker image does not set '$SGXLKL_DISK_SIZE_CONST'. Please define the LKL disk size using ENV $SGXLKL_DISK_SIZE_CONST in '$DOCKER_PATH'."
     # If we're going to exit early, we need to clean up
-    docker image rm $TMP_DOCKER_IMG_ID
-    exit -1
+    docker image rm "$TMP_DOCKER_IMG_ID"
+    exit 1
 fi
 
 # Parse out our special env values
@@ -68,12 +68,12 @@ DOCKER_IMG_ENV_PATH=$(echo "$DOCKER_IMG_ENV" | tr ' ' '\n' | grep PATH | tr '=' 
 DOCKER_IMG_ENV=$(echo "$DOCKER_IMG_ENV" | tr ' ' '\n' | grep -v "PATH=$DOCKER_IMG_ENV_PATH" | tr '\n' ' ')
 
 # Parse our other metadata
-DOCKER_IMG_ENTRY=$(docker image inspect -f "{{range \$conf := .Config.Entrypoint}}{{(\$conf)}} {{end}}" $TMP_DOCKER_IMG_ID)
-DOCKER_IMG_WORKDIR=$(docker image inspect -f "{{.Config.WorkingDir}}" $TMP_DOCKER_IMG_ID)
+DOCKER_IMG_ENTRY=$(docker image inspect -f "{{range \$conf := .Config.Entrypoint}}{{(\$conf)}} {{end}}" "$TMP_DOCKER_IMG_ID")
+DOCKER_IMG_WORKDIR=$(docker image inspect -f "{{.Config.WorkingDir}}" "$TMP_DOCKER_IMG_ID")
 
 # Generate the image, and cleanup (we're done with docker work now)
-/tools/bin/sgx-lkl-disk create --size=$DOCKER_IMG_ENV_DISK_SIZE --docker=$TMP_DOCKER_IMG_ID $DOCKER_IMG_PATH
-docker image rm $TMP_DOCKER_IMG_ID
+/tools/bin/sgx-lkl-disk create --size="$DOCKER_IMG_ENV_DISK_SIZE" --docker="$TMP_DOCKER_IMG_ID" "$DOCKER_IMG_PATH"
+docker image rm "$TMP_DOCKER_IMG_ID"
 
 echo "Entrypoint: Docker disk size: $DOCKER_IMG_ENV_DISK_SIZE"
 echo "Entrypoint: Docker environment: $DOCKER_IMG_ENV"
@@ -83,6 +83,8 @@ echo "Entrypoint: Docker entrypoint: $DOCKER_IMG_ENTRY"
 # Inflate the docker environment into our environment
 # Note: however, we don't allow the docker environment to override some things
 # Namely: PATH, SGXLKL_CWD, SGXLKL_KEY
+#
+# shellcheck disable=SC2086,SC2163
 export $DOCKER_IMG_ENV
 export PATH=$OUR_PATH
 export SGXLKL_CWD=$DOCKER_IMG_WORKDIR
@@ -90,5 +92,6 @@ export SGXLKL_KEY=$SIGN_KEY_PATH
 
 # Run lkl
 echo "Entrypoint: Running..."
-/tools/bin/sgx-lkl-run $DOCKER_IMG_PATH $DOCKER_IMG_ENTRY
+# shellcheck disable=SC2086
+/tools/bin/sgx-lkl-run "$DOCKER_IMG_PATH" $DOCKER_IMG_ENTRY
 echo "Entrypoint: Ran."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# exit when any command fails
+set -e
+
 #
 # The target that was fed to make during the build
 # We use this to make some boot up decisions
@@ -21,11 +24,6 @@ DOCKER_PATH=$4
 # The path where we'll write our docker image
 #
 DOCKER_IMG_PATH=$5
-#
-# The node entrypoint inside the docker image at which we'll start execution
-# TODO(bengreenier): refactor this to a npm start call in the app directory 
-#
-DOCKER_ENTRY_PATH=$6
 
 echo "MAKE_TARGET: $MAKE_TARGET"
 echo "SIGN_KEY_PATH: $SIGN_KEY_PATH"
@@ -35,10 +33,10 @@ echo "DOCKER_IMG_PATH: $DOCKER_IMG_PATH"
 echo "DOCKER_ENTRY_PATH: $DOCKER_ENTRY_PATH"
 
 # Generate a unique, per-runtime key with which our enclave will be signed
-/tools/bin/gen_enclave_key.sh $SIGN_KEY_PATH
+/tools/bin/gen_enclave_key.sh "$SIGN_KEY_PATH"
 
 # If we are running in hardware mode, we need to sign the enclave library
-if [ "$MAKE_TARGET" != "sim" ]; then
+if [[ "$MAKE_TARGET" != "sim" ]]; then
     echo "Entrypoint: Signing..."
     # Sign it, with the above key
     /tools/bin/sgx-lkl-sign -k $SIGN_KEY_PATH -f $SIGN_KEY_BIN_PATH
@@ -46,14 +44,51 @@ if [ "$MAKE_TARGET" != "sim" ]; then
 fi
 
 # Create our actual disk (that we'll mount in the enclave)
-/tools/bin/sgx-lkl-disk create --size=100M --docker=$DOCKER_PATH $DOCKER_IMG_PATH
+# Note: as we want to extract info (like entrypoint) from the dockerfile, we give sgx-lkl-disk an existing image, not just the dockerfile
+TMP_DOCKER_IMG_ID=$(cat /proc/sys/kernel/random/uuid)
+docker build -t $TMP_DOCKER_IMG_ID -f $DOCKER_PATH $(dirname $DOCKER_PATH)
 
-# Configure our LKL environment
-export SGXLKL_VERBOSE=1
-export SGXLKL_HEAP=640M
+# Parsing out some critical env vars demands its own section
+# We must determine the image size and remove PATH (we don't allow overriding the host app path)
+DOCKER_IMG_ENV=$(docker image inspect -f "{{range \$conf := .Config.Env}}{{(\$conf)}} {{end}}" $TMP_DOCKER_IMG_ID)
+
+SGXLKL_DISK_SIZE_CONST="SGXLKL_DISK_SIZE"
+
+# If we don't have an image size, we cannot proceed
+if [[ "$DOCKER_IMG_ENV" != *"$SGXLKL_DISK_SIZE_CONST"* ]]; then
+    echo "Docker image does not set '$SGXLKL_DISK_SIZE_CONST'. Please define the LKL disk size using ENV $SGXLK_DISK_SIZE_CONST in '$DOCKER_PATH'."
+    # If we're going to exit early, we need to clean up
+    docker image rm $TMP_DOCKER_IMG_ID
+    exit -1
+fi
+
+# Parse out our special env values
+DOCKER_IMG_ENV_DISK_SIZE=$(echo "$DOCKER_IMG_ENV" | tr ' ' '\n' | grep "$SGXLKL_DISK_SIZE_CONST" | tr '=' '\n' | sed -n 2p)
+DOCKER_IMG_ENV_PATH=$(echo "$DOCKER_IMG_ENV" | tr ' ' '\n' | grep PATH | tr '=' '\n' | sed -n 2p)
+DOCKER_IMG_ENV=$(echo "$DOCKER_IMG_ENV" | tr ' ' '\n' | grep -v "PATH=$DOCKER_IMG_ENV_PATH" | tr '\n' ' ')
+
+# Parse our other metadata
+DOCKER_IMG_ENTRY=$(docker image inspect -f "{{range \$conf := .Config.Entrypoint}}{{(\$conf)}} {{end}}" $TMP_DOCKER_IMG_ID)
+DOCKER_IMG_WORKDIR=$(docker image inspect -f "{{.Config.WorkingDir}}" $TMP_DOCKER_IMG_ID)
+
+# Generate the image, and cleanup (we're done with docker work now)
+/tools/bin/sgx-lkl-disk create --size=$DOCKER_IMG_ENV_DISK_SIZE --docker=$TMP_DOCKER_IMG_ID $DOCKER_IMG_PATH
+docker image rm $TMP_DOCKER_IMG_ID
+
+echo "Entrypoint: Docker disk size: $DOCKER_IMG_ENV_DISK_SIZE"
+echo "Entrypoint: Docker environment: $DOCKER_IMG_ENV"
+echo "Entrypoint: Docker working directory: $DOCKER_IMG_WORKDIR"
+echo "Entrypoint: Docker entrypoint: $DOCKER_IMG_ENTRY"
+
+# Inflate the docker environment into our environment
+# Note: however, we don't allow the docker environment to override some things
+# Namely: PATH, SGXLKL_CWD, SGXLKL_KEY
+export $DOCKER_IMG_ENV
+export PATH=$OUR_PATH
+export SGXLKL_CWD=$DOCKER_IMG_WORKDIR
 export SGXLKL_KEY=$SIGN_KEY_PATH
 
 # Run lkl
 echo "Entrypoint: Running..."
-/tools/bin/sgx-lkl-run $DOCKER_IMG_PATH /usr/bin/node --max-old-space-size=512 $DOCKER_ENTRY_PATH
+/tools/bin/sgx-lkl-run $DOCKER_IMG_PATH $DOCKER_IMG_ENTRY
 echo "Entrypoint: Ran."

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,7 +4,13 @@ WORKDIR /app
 RUN apk --update upgrade && \
     apk add nodejs npm
 COPY ./ ./
+
+# Enable SGXLKL verbosity
 ENV SGXLKL_VERBOSE=1
-ENV SGXLKL_HEAP=2048M
+# Scale up the SGXLKL heap size
+ENV SGXLKL_HEAP=640M
+# Size our SGXLKL disk
+# Note: This is the only __mandatory__ option
 ENV SGXLKL_DISK_SIZE=100M
-ENTRYPOINT ["/usr/bin/node", "index.js"]
+
+ENTRYPOINT ["/usr/bin/node", "--max-old-space-size=512", "index.js"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -4,4 +4,7 @@ WORKDIR /app
 RUN apk --update upgrade && \
     apk add nodejs npm
 COPY ./ ./
-ENTRYPOINT [ "/usr/bin/npm", "start" ]
+ENV SGXLKL_VERBOSE=1
+ENV SGXLKL_HEAP=2048M
+ENV SGXLKL_DISK_SIZE=100M
+ENTRYPOINT ["/usr/bin/node", "index.js"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -5,6 +5,9 @@ RUN apk --update upgrade && \
     apk add nodejs npm
 COPY ./ ./
 
+# Used by the app to customize our greeting
+ENV APP_WORLD_TAG="human"
+
 # Enable SGXLKL verbosity
 ENV SGXLKL_VERBOSE=1
 # Scale up the SGXLKL heap size

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-console.log("Hello world. I'm inside an enclave!")
+console.log(`Hello ${process.env.APP_WORLD_TAG || "world"}. I'm inside an enclave!`)


### PR DESCRIPTION
This PR enables this pattern to be viable for __any__ `src` runtime. It also allows a `src` app to fully configure itself via it's dockerfile. It does so by demanding some `ENV` values are set (namely `SGXLKL_DISK_SIZE`). Here's what I've added:

+ Use `ENTRYPOINT` directive to determine lkl enclave entry point
+ Support `ENV` directive to set environment variables, in both the host session, and the lkl session.
+ Support metadata env directive `SGXLKL_DISK_SIZE` to configure the size of the lkl enclave image
+ Support forwarding `SGXLKL_VERBOSE` and similar flags to the runtime
+ Update example to use customization env var if present
+ Modify entrypoint image generation to support this new paradigm


Known bugs:
+ ENV values with spaces in them break things. This is pretty significant, and should be fixed ASAP 